### PR TITLE
Updating download link

### DIFF
--- a/netpanzer/templates/index.html
+++ b/netpanzer/templates/index.html
@@ -14,7 +14,7 @@
                     <h2>Junte-se à comunidade de jogadores de NetPanzer e prove sua habilidade tática nas batalhas de
                         tanques.
                     </h2>
-                    <a href="{% static 'assets/game/instalador-netpanzer.msi' %}" class="btn-get-started scrollto">Download</a>
+                    <a href="https://github.com/netpanzer/netpanzer/releases" class="btn-get-started scrollto">Download</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
All download links should just go to release page for now. In the near future, we will have a fancy download page, and it will automatically update with the latest release links.